### PR TITLE
Add minimal Ethereum scaffolding

### DIFF
--- a/src/cryptoadvance/specter/config.py
+++ b/src/cryptoadvance/specter/config.py
@@ -6,7 +6,14 @@ import random
 import secrets
 from pathlib import Path
 
-from dotenv import load_dotenv
+# ``python-dotenv`` is an optional dependency used in development. Some
+# environments (like the minimal test container) might not provide it, so we
+# gracefully fallback if it is missing.
+try:  # pragma: no cover - optional dependency
+    from dotenv import load_dotenv
+except ModuleNotFoundError:  # pragma: no cover - handled in tests
+    def load_dotenv(*args, **kwargs):  # type: ignore
+        return False
 
 # BASEDIR = os.path.abspath(os.path.dirname(__file__))
 

--- a/src/cryptoadvance/specter/ethereum/__init__.py
+++ b/src/cryptoadvance/specter/ethereum/__init__.py
@@ -1,0 +1,1 @@
+"""Ethereum support modules for Specter."""

--- a/src/cryptoadvance/specter/ethereum/node.py
+++ b/src/cryptoadvance/specter/ethereum/node.py
@@ -1,0 +1,35 @@
+"""Minimal Ethereum node representation."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+from ..node import AbstractNode
+from .rpc import EthereumRPC
+
+
+@dataclass
+class EthereumNode(AbstractNode):
+    """A lightweight :class:`~cryptoadvance.specter.node.AbstractNode` implementation
+    for Ethereum networks.
+
+    Only a subset of :class:`AbstractNode` functionality is implemented; methods
+    unrelated to Ethereum are intentionally minimal.
+    """
+
+    url: str = "http://localhost:8545"
+    chain_id: int = 1
+    _rpc: Optional[EthereumRPC] = None
+
+    def update_rpc(self) -> None:
+        self._rpc = EthereumRPC(self.url)
+
+    @property
+    def rpc(self) -> EthereumRPC:
+        if self._rpc is None:
+            self.update_rpc()
+        return self._rpc
+
+    def node_info_template(self) -> str:
+        """Return path to an Ethereum specific node info template."""
+        return "node/components/ethereum_node_info.jinja"

--- a/src/cryptoadvance/specter/ethereum/rpc.py
+++ b/src/cryptoadvance/specter/ethereum/rpc.py
@@ -1,0 +1,52 @@
+"""Minimal Ethereum JSON-RPC client using web3.py."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+try:
+    from web3 import Web3
+except ImportError:  # pragma: no cover - handled in tests
+    Web3 = None  # type: ignore
+
+
+@dataclass
+class EthereumRPC:
+    """Light-weight wrapper around :mod:`web3` for a few common RPC calls.
+
+    Parameters
+    ----------
+    provider_uri: str, optional
+        HTTP provider URI. If not provided, ``provider`` must be passed.
+    provider: Any, optional
+        Instance of a ``web3`` provider. Useful for testing with
+        :class:`web3.EthereumTesterProvider`.
+    """
+
+    provider_uri: Optional[str] = None
+    provider: Optional[object] = None
+
+    def __post_init__(self) -> None:
+        if Web3 is None:  # pragma: no cover - defensive programming
+            raise ImportError("web3 is required for EthereumRPC")
+        if self.provider is not None:
+            self.web3 = Web3(self.provider)
+        else:
+            uri = self.provider_uri or "http://localhost:8545"
+            self.web3 = Web3(Web3.HTTPProvider(uri))
+
+    def get_balance(self, address: str) -> int:
+        """Return the balance for ``address`` in wei."""
+        return self.web3.eth.get_balance(address)
+
+    def get_transaction_count(self, address: str) -> int:
+        """Return the nonce for ``address``."""
+        return self.web3.eth.get_transaction_count(address)
+
+    def send_raw_transaction(self, raw_tx: bytes) -> bytes:
+        """Broadcast ``raw_tx`` to the network."""
+        return self.web3.eth.send_raw_transaction(raw_tx)
+
+    def get_transaction_receipt(self, tx_hash: bytes):
+        """Fetch the transaction receipt for ``tx_hash``."""
+        return self.web3.eth.get_transaction_receipt(tx_hash)

--- a/src/cryptoadvance/specter/ethereum/wallet.py
+++ b/src/cryptoadvance/specter/ethereum/wallet.py
@@ -1,0 +1,61 @@
+"""Utilities for constructing and sending Ethereum transactions."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+try:
+    from eth_account import Account
+except ImportError:  # pragma: no cover - handled in tests
+    Account = None  # type: ignore
+
+from .rpc import EthereumRPC
+
+
+@dataclass
+class EthereumWallet:
+    """Simple Ethereum wallet bound to a single private key."""
+
+    rpc: EthereumRPC
+    private_key: str
+
+    def __post_init__(self) -> None:
+        if Account is None:  # pragma: no cover - defensive
+            raise ImportError("eth-account is required for EthereumWallet")
+        self._account = Account.from_key(self.private_key)
+
+    @property
+    def address(self) -> str:
+        return self._account.address
+
+    def get_balance(self) -> int:
+        return self.rpc.get_balance(self.address)
+
+    def create_transaction(
+        self,
+        to: str,
+        value: int,
+        gas: int = 21_000,
+        gas_price: Optional[int] = None,
+        nonce: Optional[int] = None,
+        chain_id: int = 1,
+    ) -> dict:
+        if gas_price is None:
+            gas_price = self.rpc.web3.eth.gas_price
+        if nonce is None:
+            nonce = self.rpc.get_transaction_count(self.address)
+        return {
+            "to": to,
+            "value": value,
+            "gas": gas,
+            "gasPrice": gas_price,
+            "nonce": nonce,
+            "chainId": chain_id,
+        }
+
+    def sign_transaction(self, tx: dict) -> bytes:
+        signed = self._account.sign_transaction(tx)
+        return signed.rawTransaction
+
+    def send_transaction(self, raw_tx: bytes) -> bytes:
+        return self.rpc.send_raw_transaction(raw_tx)

--- a/src/cryptoadvance/specter/node.py
+++ b/src/cryptoadvance/specter/node.py
@@ -25,6 +25,15 @@ from .rpc import (
 from .specter_error import SpecterError, BrokenCoreConnectionException
 from .device import Device
 
+# Default configuration values for Ethereum connections. These are intentionally
+# minimal and are used by :class:`~cryptoadvance.specter.ethereum.node.EthereumNode`.
+ETH_DEFAULT_RPC_PORT = 8545
+ETH_CHAIN_IDS = {
+    "main": 1,
+    "goerli": 5,
+    "sepolia": 11155111,
+}
+
 logger = logging.getLogger(__name__)
 
 

--- a/tests/ethereum/pytest.ini
+++ b/tests/ethereum/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+addopts =

--- a/tests/ethereum/test_wallet.py
+++ b/tests/ethereum/test_wallet.py
@@ -1,0 +1,21 @@
+import pytest
+
+web3 = pytest.importorskip("web3")
+
+from web3 import EthereumTesterProvider
+from cryptoadvance.specter.ethereum.rpc import EthereumRPC
+from cryptoadvance.specter.ethereum.wallet import EthereumWallet
+
+
+def test_send_transaction():
+    provider = EthereumTesterProvider()
+    rpc = EthereumRPC(provider=provider)
+    tester = provider.ethereum_tester
+    acct0, acct1 = tester.get_accounts()[:2]
+    key = tester.backend.account_keys[0].to_hex()
+    wallet = EthereumWallet(rpc, key)
+    tx = wallet.create_transaction(to=acct1, value=1, chain_id=tester.get_chain_id())
+    raw = wallet.sign_transaction(tx)
+    tx_hash = wallet.send_transaction(raw)
+    receipt = rpc.get_transaction_receipt(tx_hash)
+    assert receipt["status"] == 1


### PR DESCRIPTION
## Summary
- introduce lightweight Ethereum RPC client built on web3
- add EthereumNode and EthereumWallet with basic transaction utilities
- allow config to run without python-dotenv dependency
- add placeholder tests exercising Ethereum wallet flow

## Testing
- `PYTHONPATH=src pytest tests/ethereum/test_wallet.py -q -c tests/ethereum/pytest.ini --confcutdir=tests/ethereum`

------
https://chatgpt.com/codex/tasks/task_e_68a1d836f7dc83328d4a70e327e3f832